### PR TITLE
fix: use correct namespace for NRetry

### DIFF
--- a/src/NUnitRetry.ReqnrollPlugin/TestGeneratorProvider.cs
+++ b/src/NUnitRetry.ReqnrollPlugin/TestGeneratorProvider.cs
@@ -10,7 +10,7 @@ namespace NUnitRetry.ReqnrollPlugin
 {
     public class TestGeneratorProvider : NUnit3TestGeneratorProvider
     {
-        protected internal const string RETRY_ATTR = "NUnit.Framework.NRetry";
+        protected internal const string RETRY_ATTR = "NRetry";
 
         private readonly RetryConfiguration _configuration;
 

--- a/src/NUnitRetry.Tests/NRetryCommandTests.cs
+++ b/src/NUnitRetry.Tests/NRetryCommandTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
+using NUnitRetry;
 using Shouldly;
 using System;
 

--- a/src/NUnitRetry.Tests/RetryOnAttributeTests.cs
+++ b/src/NUnitRetry.Tests/RetryOnAttributeTests.cs
@@ -1,7 +1,7 @@
 using NUnit.Framework;
 using System;
 
-namespace RetryOnException.NUnit.Tests;
+namespace NUnitRetry.Tests;
 
 public class NRetryAttributeTests
 {
@@ -9,7 +9,7 @@ public class NRetryAttributeTests
 
     /// <summary>
     /// Gets the total number of scenario attempts.
-    /// Adjusts for NUnit's <see cref="NUnit.Framework.TestContext.CurrentContext.CurrentRepeatCount"/> 
+    /// Adjusts for NUnit's <see cref="Framework.TestContext.CurrentContext.CurrentRepeatCount"/> 
     /// by adding 1 to include the initial attempt.
     /// </summary>
     private int TotalScenarioAttempts => TestContext.CurrentContext.CurrentRepeatCount + 1;

--- a/src/NUnitRetry/NRetryAttribute.cs
+++ b/src/NUnitRetry/NRetryAttribute.cs
@@ -1,9 +1,9 @@
+using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
-using RetryOnException.NUnit;
 using System;
 
-namespace NUnit.Framework
+namespace NUnitRetry
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public sealed class NRetryAttribute : NUnitAttribute, IRepeatTest

--- a/src/NUnitRetry/NRetryCommand.cs
+++ b/src/NUnitRetry/NRetryCommand.cs
@@ -3,7 +3,7 @@ using NUnit.Framework.Internal;
 using NUnit.Framework.Internal.Commands;
 using System;
 
-namespace RetryOnException.NUnit;
+namespace NUnitRetry;
 
 public sealed class NRetryCommand : DelegatingTestCommand
 {


### PR DESCRIPTION
fix: use correct namespace for NRetry