### PR TITLE
fix: adjust dll output paths in nuspec file

### DIFF
--- a/src/NUnitRetry.ReqnrollPlugin/NUnitRetry.ReqnrollPlugin.nuspec
+++ b/src/NUnitRetry.ReqnrollPlugin/NUnitRetry.ReqnrollPlugin.nuspec
@@ -18,6 +18,7 @@
   <files>
 	<file src="build\**\*" target="build"/>
 	  
-    <file src="bin\$config$\netstandard2.0\NUnitRetry*.dll" target="build\netstandard2.0" />
+    <file src="bin\$config$\netstandard2.0\NUnitRetry.dll" target="lib\netstandard2.0" />
+	<file src="bin\$config$\netstandard2.0\NUnitRetry.ReqnrollPlugin.*" target="build\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
fix: adjust dll output paths in nuspec file